### PR TITLE
Role

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,4 +8,13 @@ class ApplicationController < ActionController::Base
       clients_dashboard_path # or whatever path you want for clients
     end
   end
+
+  # Allow Devise to accept the role parameter during sign-up
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:role])
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   devise :database_authenticatable, :registerable, :recoverable, :rememberable, :validatable
+  validates :role, presence: true, inclusion: { in: %w[barber client] }
 
   # Example: Check if user is a barber
   def barber?

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -21,6 +21,14 @@
     <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
   </div>
 
+  <div class="field">
+    <%= f.label :role, "I am a..." %><br />
+    <%= f.radio_button :role, 'barber' %>
+    <%= f.label :role_barber, 'Barber' %><br />
+    <%= f.radio_button :role, 'client' %>
+    <%= f.label :role_client, 'Client' %>
+  </div>
+
   <div class="actions">
     <%= f.submit "Sign up" %>
   </div>


### PR DESCRIPTION
Today, we added a role selection to the sign-up form, allowing users to choose between "barber" or "client." After adding a validation to ensure the role is present and correctly set, we encountered an issue where the form would throw errors saying "Role can't be blank" and "Role is not included in the list." The issue was that the role wasn’t being passed through to Devise, so we fixed it by updating the ApplicationController to permit the role field with devise_parameter_sanitizer.permit(:sign_up, keys: [:role]). After that, everything worked smoothly, and users can now select their role during sign-up without any issues.