### PR TITLE
Barbershops 1

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,15 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def after_sign_in_path_for(resource)
+    if resource.is_a?(Barber)
+      barbers_dashboard_path
+    else
+      barbershops_path
+    end
+  end
+
+
   # Allow Devise to accept the role parameter during sign-up
   before_action :configure_permitted_parameters, if: :devise_controller?
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
     if resource.is_a?(Barber)
       barbers_dashboard_path # or whatever path you want for barbers
     else
-      clients_dashboard_path # or whatever path you want for clients
+      barbershops_path # or whatever path you want for clients
     end
   end
 

--- a/app/controllers/barbershops_controller.rb
+++ b/app/controllers/barbershops_controller.rb
@@ -3,6 +3,7 @@ class BarbershopsController < ApplicationController
   before_action :authenticate_user!, only: [:index, :show]  # Ensure the user is logged in
 
   def index
+    logger.debug "Current user: #{current_user.inspect}"  # Check who the current user is
     @barbershops = Barbershop.all
   end
 

--- a/app/controllers/barbershops_controller.rb
+++ b/app/controllers/barbershops_controller.rb
@@ -3,7 +3,6 @@ class BarbershopsController < ApplicationController
   before_action :authenticate_user!, only: [:index, :show]  # Ensure the user is logged in
 
   def index
-    logger.debug "Current user: #{current_user.inspect}"  # Check who the current user is
     @barbershops = Barbershop.all
   end
 


### PR DESCRIPTION
✅ Redirect + Barbershop Display Debug Summary
Issue:
After signing in, users landed on the homepage (home#index) instead of the barbershop listing at /barbershops. Even though barbershops were seeded and viewable via direct URL, they didn’t appear post-login.

Root Cause:
Rails was using the default after_sign_in_path_for method, which redirected users to root (/). The after_sign_up_path_for was customized, but not after_sign_in_path_for, so it wasn’t redirecting where we wanted.

Fix:
We added a custom after_sign_in_path_for method in ApplicationController like so:

ruby
Copy
Edit
def after_sign_in_path_for(resource)
  if resource.is_a?(Barber)
    barbers_dashboard_path
  else
    barbershops_path
  end
end
Now, post-login redirection sends users to the correct dashboard or barbershop index 🎯