### PR TITLE
Navbar

### DIFF
--- a/app/assets/stylesheets/_navbar.scss
+++ b/app/assets/stylesheets/_navbar.scss
@@ -1,0 +1,32 @@
+.navbar {
+  position: sticky;
+  top: 0;
+  width: 100%;
+  background-color: $secondary-color;
+  padding: 1rem 2rem;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  z-index: 1000;
+
+  .navbar-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .navbar-brand a {
+    font-family: $font-family;
+    font-size: 1.5rem;
+    color: #fff;
+    text-decoration: none;
+  }
+
+  .navbar-links {
+    a, .sign-out-btn {
+      font-family: $font-family;
+      color: #fff;
+      text-decoration: none;
+      margin-left: 1rem;
+      &:hover { text-decoration: underline; }
+    }
+  }
+}

--- a/app/assets/stylesheets/_navbar.scss
+++ b/app/assets/stylesheets/_navbar.scss
@@ -2,7 +2,7 @@
   position: sticky;
   top: 0;
   width: 100%;
-  background-color: $secondary-color;
+  background-color: hotpink !important;
   padding: 1rem 2rem;
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
   z-index: 1000;

--- a/app/assets/stylesheets/_navbar.scss
+++ b/app/assets/stylesheets/_navbar.scss
@@ -4,7 +4,7 @@
   position: sticky;
   top: 0;
   width: 100%;
-  background-color: hotpink !important;
+  background-color: $secondary-color;
   padding: 1rem 2rem;
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
   z-index: 1000;

--- a/app/assets/stylesheets/_navbar.scss
+++ b/app/assets/stylesheets/_navbar.scss
@@ -1,3 +1,5 @@
+@import "variables";
+
 .navbar {
   position: sticky;
   top: 0;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,3 +3,4 @@
 @import 'layout';
 @import 'components';
 @import 'responsive';
+@import 'navbar';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,6 @@
 @import 'variables';
+@import 'navbar';
 @import 'base';
 @import 'layout';
 @import 'components';
 @import 'responsive';
-@import 'navbar';

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,7 +9,7 @@
 
   </head>
   <body>
-    <%= render 'shared/navbar' %>
+    <%= render partial: 'shared/navbar' %>
     <%= yield %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,22 +9,7 @@
 
   </head>
   <body>
-    <nav class="navbar">
-      <div class="navbar-container">
-        <div class="navbar-brand">
-          <%= link_to "Barber Booking", root_path %>
-        </div>
-        <div class="navbar-links">
-          <% if user_signed_in? %>
-            <%= link_to "Logout", destroy_user_session_path, method: :delete %>
-          <% else %>
-            <%= link_to "Sign In", new_user_session_path %> |
-            <%= link_to "Sign Up", new_user_registration_path %>
-          <% end %>
-        </div>
-      </div>
-    </nav>
-
+    <%= render 'shared/navbar' %>
     <%= yield %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,12 +9,21 @@
 
   </head>
   <body>
-    <% if user_signed_in? %>
-      <%= button_to 'Sign Out', destroy_user_session_path, method: :delete %>
-    <% else %>
-      <%= link_to 'Sign In', new_user_session_path %>
-      <%= link_to 'Sign Up', new_user_registration_path %>
-    <% end %>
+    <nav class="navbar">
+      <div class="navbar-container">
+        <div class="navbar-brand">
+          <%= link_to "Barber Booking", root_path %>
+        </div>
+        <div class="navbar-links">
+          <% if user_signed_in? %>
+            <%= link_to "Logout", destroy_user_session_path, method: :delete %>
+          <% else %>
+            <%= link_to "Sign In", new_user_session_path %> |
+            <%= link_to "Sign Up", new_user_registration_path %>
+          <% end %>
+        </div>
+      </div>
+    </nav>
 
     <%= yield %>
   </body>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,0 +1,15 @@
+<nav class="navbar">
+  <div class="navbar-container">
+    <div class="navbar-brand">
+      <%= link_to "Barber Booking", root_path %>
+    </div>
+    <div class="navbar-links">
+      <% if user_signed_in? %>
+        <%= link_to "Logout", destroy_user_session_path, method: :delete %>
+      <% else %>
+        <%= link_to "Sign In", new_user_session_path %> |
+        <%= link_to "Sign Up", new_user_registration_path %>
+      <% end %>
+    </div>
+  </div>
+</nav>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -5,7 +5,7 @@
     </div>
     <div class="navbar-links">
       <% if user_signed_in? %>
-        <%= link_to "Logout", destroy_user_session_path, method: :delete %>
+        <%= button_to "Logout", destroy_user_session_path, method: :delete %>
       <% else %>
         <%= link_to "Sign In", new_user_session_path %> |
         <%= link_to "Sign Up", new_user_registration_path %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,4 +73,7 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+
+  config.assets.debug = true
+
 end


### PR DESCRIPTION
We started by fixing those pesky undefined‐variable errors—adding @import "variables"; at the top of every partial that used $font‑family or $secondary‑color (including _base.scss, _components.scss, and finally _navbar.scss), then we refactored the navbar into its own partial (app/views/shared/_navbar.html.erb) and rendered it in application.html.erb to stay DRY, wired up the styles by importing "navbar" only in application.scss, and even dropped a hot‑pink background test to confirm CSS was loading; after spotting and removing the accidental recursive import inside _navbar.scss, we restarted Rails, recompiled assets, and—boom—the sticky, styled navbar appeared and the logout button worked perfectly.