### PR TITLE
Debug 1

### DIFF
--- a/app/views/barbershops/index.html.erb
+++ b/app/views/barbershops/index.html.erb
@@ -5,7 +5,7 @@
 <% else %>
   <% @barbershops.each do |barbershop| %>
     <div class="shop-card">
-      <% if barbershop.photo.attached? %>
+      <% if barbershop.photo.present? %>
         <%= image_tag barbershop.photo, alt: barbershop.name, class: "shop-image" %>
       <% else %>
         <p>No photo available</p>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,7 +2,7 @@ require 'faker'
 require 'httparty'
 
 # Unsplash API
-UNSPLASH_API_URL = "https://api.unsplash.com/photos/random?query=barbershop&client_id=YOUR_UNSPLASH_ACCESS_KEY"
+UNSPLASH_API_URL = "https://api.unsplash.com/photos/random?query=barbershop&client_id=#{ENV['UNSPLASH_ACCESS_KEY']}"
 
 # Clear old data
 Barbershop.destroy_all

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,6 +19,8 @@ User.destroy_all
 
   # Fetch a random barbershop image from Unsplash
   response = HTTParty.get(UNSPLASH_API_URL)
+  puts response.parsed_response.class
+  puts response.parsed_response
   image_url = response.parsed_response.first['urls']['regular']
 
   # Each barber owns 1-2 barbershops

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -21,7 +21,8 @@ User.destroy_all
   response = HTTParty.get(UNSPLASH_API_URL)
   puts response.parsed_response.class
   puts response.parsed_response
-  image_url = response.parsed_response.first['urls']['regular']
+  image_url = response.parsed_response['urls']['regular']
+
 
   # Each barber owns 1-2 barbershops
   rand(1..2).times do


### PR DESCRIPTION
Today I learned that using barbershop.photo.attached? only works with ActiveStorage attachments, not when storing plain image URLs in a string column. Since I’m saving image URLs (like from Unsplash) directly in the photo string field, I needed to use barbershop.photo.present? instead to check if an image exists. This fixed the error and let me display barbershop images properly in the index view.